### PR TITLE
Add support for observable-specific biases

### DIFF
--- a/src/cssrlib/peph.py
+++ b/src/cssrlib/peph.py
@@ -857,6 +857,9 @@ class biasdec():
                 elif '-BIAS/SOLUTION' in line:
                     status = False
                 if status and line[0:5] == ' DSB ':
+                    # Skip station DSBs
+                    if line[15:24].strip():
+                        continue
                     # Differential Signal Bias
                     svn = int(line[7:10])
                     prn = line[11:14]
@@ -886,8 +889,10 @@ class biasdec():
                     if len(line) >= 137:
                         slope = float(line[104:125])
                         std_s = float(line[126:137])
-                    print("{:3d} {:3d} {:s} {:s} {:f}".format(
-                        svn, sat, obs1, obs2, bias))
+
+                    print("{:3d} {:3d} {:s} {:s} {:7.3f}"
+                          .format(svn, sat, obs1, obs2, bias))
+
                     dcb = bias_t(sat, tst, ted, type1, code1,
                                  type2, code2, bias, std, svn)
                     self.dcb.append(dcb)

--- a/src/cssrlib/pppigs.py
+++ b/src/cssrlib/pppigs.py
@@ -1,5 +1,5 @@
 """
-module for PPP-RTK positioing
+module for standard PPP positioning
 """
 from collections import defaultdict
 from copy import copy
@@ -133,7 +133,6 @@ def rtkinit(nav, pos0=np.zeros(3)):
     nav.sig_qp = 0.01
     nav.sig_qv = 1.0
     nav.sig_qion = 10.0  # [m/sqrt(s)]
-    # nav.sig_qztd = 0.005/np.sqrt(3600)  # [m/sqrt(s)]
     nav.sig_qztd = 0.1e-3/np.sqrt(30)  # [m/sqrt(s)]
 
     nav.tidecorr = True

--- a/src/cssrlib/test/test_peph.py
+++ b/src/cssrlib/test/test_peph.py
@@ -13,6 +13,8 @@ orbfile = bdir+"COD0IGSRAP/2021/COD0IGSRAP_20210780000_01D_15M_ORB.SP3"
 clkfile = bdir+"COD0IGSRAP/2021/COD0IGSRAP_20210780000_01D_30S_CLK.CLK"
 atxfile = bdir+"IGS/ANTEX/igs14.atx"
 dcbfile = bdir+"COD0IGSRAP/2021/COD0IGSRAP_20210780000_01D_01D_OSB.BIA"
+#dcbfile = bdir+"CAS0MGXRAP/2021/CAS0MGXRAP_20210780000_01D_01D_DCB.BSX"
+#dcbfile = bdir+"CAS0MGXRAP/2021/CAS0MGXRAP_20210780000_01D_01D_OSB.BIA"
 
 time = epoch2time([2021, 3, 19, 0, 0, 0])
 sat = 3
@@ -45,14 +47,19 @@ if False:
     rs, dts, var = sp.peph2pos(time, sat, nav)
     off = satantoff(time, rs[0:3], sat, nav)
 
-if False:
-
-    time = epoch2time([2022, 12, 31, 0, 0, 0])
-    sat = 3
+if True:
 
     bd = biasdec()
     bd.parse(dcbfile)
-    bias, std, bcode = bd.getdcb(sat, time, rSIG.L1W)
-    assert bias == -1.2715
-    assert std == 0.0058
-    assert bcode == rSIG.L1C
+
+    sig = "C1W"
+    bias, std, = bd.getosb(sat, time, sig)
+    assert bias == 7.6934
+    assert std == 0.0
+    print("{:02d} {:s} {:8.5f} {:6.4f}".format(sat, sig, bias, std))
+
+    sig = "L1W"
+    bias, std, = bd.getosb(sat, time, sig)
+    assert bias == 0.00038
+    assert std == 0.0
+    print("{:02d} {:s} {:8.5f} {:6.4f}".format(sat, sig, bias, std))


### PR DESCRIPTION
Add support for observable specific biases (OSBs) and skip station DSB and OSB values in Bias-SINEX files. Handle signal identifies as strings (for now)