### PR TITLE
add doppler for rinex

### DIFF
--- a/src/cssrlib/gnss.py
+++ b/src/cssrlib/gnss.py
@@ -652,6 +652,7 @@ class Obs():
         self.t = gtime_t()
         self.P = []
         self.L = []
+        self.D = []
         self.S = []
         self.lli = []
         self.sat = []

--- a/src/cssrlib/rinex.py
+++ b/src/cssrlib/rinex.py
@@ -860,6 +860,7 @@ class rnxdec:
             #
             obs.P = np.empty((0, self.nsig[uTYP.C]), dtype=np.float64)
             obs.L = np.empty((0, self.nsig[uTYP.L]), dtype=np.float64)
+            obs.D = np.empty((0, self.nsig[uTYP.D]), dtype=np.float64)
             obs.S = np.empty((0, self.nsig[uTYP.S]), dtype=np.float64)
             obs.lli = np.empty((0, self.nsig[uTYP.L]), dtype=np.int32)
             obs.sat = np.empty(0, dtype=np.int32)
@@ -895,6 +896,8 @@ class rnxdec:
                               dtype=np.float64)
                 ll = np.zeros(len(self.getSignals(sys, uTYP.L)),
                               dtype=np.int32)
+                dp = np.zeros(len(self.getSignals(sys, uTYP.D)),
+                              dtype=np.float64)
                 cn = np.zeros(len(self.getSignals(sys, uTYP.S)),
                               dtype=np.float64)
 
@@ -925,6 +928,8 @@ class rnxdec:
                     elif sig.typ == uTYP.L:
                         cp[j] = val
                         ll[j] = lli
+                    elif sig.typ == uTYP.D:
+                        dp[j] = val
                     elif sig.typ == uTYP.S:
                         cn[j] = val
                     else:
@@ -934,12 +939,14 @@ class rnxdec:
                 #
                 obs.P = np.append(obs.P, pr)
                 obs.L = np.append(obs.L, cp)
+                obs.D = np.append(obs.D, dp)
                 obs.S = np.append(obs.S, cn)
                 obs.lli = np.append(obs.lli, ll)
                 obs.sat = np.append(obs.sat, sat)
 
             obs.P = obs.P.reshape(len(obs.sat), self.nsig[uTYP.C])
             obs.L = obs.L.reshape(len(obs.sat), self.nsig[uTYP.L])
+            obs.D = obs.D.reshape(len(obs.sat), self.nsig[uTYP.D])
             obs.S = obs.S.reshape(len(obs.sat), self.nsig[uTYP.S])
             obs.lli = obs.lli.reshape(len(obs.sat), self.nsig[uTYP.L])
 


### PR DESCRIPTION
Hello, I would like to use cssrlib as a dataloader for my GNSS processing. However, cssrlib does not currently load Doppler measurements.
If this does not affect your implementation, could you please add Doppler support?